### PR TITLE
Support `json-ts-mode`, falling back to `json-mode` otherwise.

### DIFF
--- a/swagg.el
+++ b/swagg.el
@@ -542,8 +542,10 @@ tries to display the RESPONSE according to it's content-type."
              (downcase))
       ("application/json"
        (json-pretty-print-buffer)
-       (require 'json-mode)
-       (json-mode))
+       (if (featurep 'json-ts-mode)
+           (json-ts-mode)
+         (require 'json-mode)
+         (json-mode)))
       (_ (prog-mode)))
     (setq
      header-line-format


### PR DESCRIPTION
This PR checks for whether `json-ts-mode` is available, and uses it to highlight JSON payloads instead of using `json-mode` which isn't part of Emacs by default.